### PR TITLE
Add showUserFeedback parameter to enable feedback option in bot responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ class WebhookAdapter {
 
     for (const response of responses) {
       const { type, message } = response;
+      const showUserFeedback = response.showUserFeedback || false;
 
       if (type === "Text") {
         fulfillmentMessages.push({
@@ -115,6 +116,7 @@ class WebhookAdapter {
           },
           platform: "PLATFORM_UNSPECIFIED",
           message: "text",
+          showUserFeedback,
         });
       }
 
@@ -123,6 +125,7 @@ class WebhookAdapter {
           payload: message,
           platform: "PLATFORM_UNSPECIFIED",
           message: "payload",
+          showUserFeedback,
         });
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dialogflow-nodejs-package",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A Dialogflow package to use in projects.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Overview
This pull request introduces a new feature in the dialogflow-nodejs-package library by adding the showUserFeedback parameter. This enhancement allows developers to specify whether user feedback options should be displayed in chatbot responses.

### Key Changes
- Added showUserFeedback parameter to the relevant response functions in the library.

### Issues Addressed
None directly, but this update provides developers using the dialogflow-nodejs-package with greater flexibility in customizing user interactions by enabling or disabling feedback prompts in chatbot responses.