### PR TITLE
Add optional payload handling for Text responses and bump version to 1.0.10

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ class WebhookAdapter {
 
 
     for (const response of responses) {
-      const { type, message } = response;
+      const { type, message, payload } = response;
       const showUserFeedback = response.showUserFeedback || false;
 
       if (type === "Text") {
@@ -137,6 +137,7 @@ class WebhookAdapter {
           platform,
           message: "text",
           showUserFeedback,
+          ...(payload ? { payload } : {}),
         });
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dialogflow-nodejs-package",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A Dialogflow package to use in projects.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR enhances the WebhookAdapter to include an optional payload field when processing Text-type responses. If a payload is present, it is merged into the response object. Additionally, the package version is incremented from 1.0.9 to 1.0.10 to reflect this update.